### PR TITLE
Fix logout functionality in HomeActivity to ensure user is signed out…

### DIFF
--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/home/HomeActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/home/HomeActivity.java
@@ -34,6 +34,7 @@ public class HomeActivity extends BaseActivity {
         loadUserProfile();
 
         findViewById(R.id.btn_logout).setOnClickListener(v -> {
+            AuthRepository.getInstance().signOut();
             startActivity(new Intent(this, LoginActivity.class));
             finishAffinity();
         });

--- a/notes/LOGS_CHANGES.md
+++ b/notes/LOGS_CHANGES.md
@@ -423,3 +423,5 @@
 - `app/src/main/AndroidManifest.xml` (updated)
 
 **Notes:** User cannot leave Onboarding without submitting the form (back is intercepted). Profile is written to `users/{uid}` (name, gender, birthday, email). Home displays the saved name at the top; avatar stays the default (no Firebase Storage).
+
+**Fix (logout):** Logout was only navigating to LoginActivity without signing out of Firebase Auth, so reopening the app showed the user still logged in. HomeActivity now calls `AuthRepository.getInstance().signOut()` before starting LoginActivity and finishing, so the Firebase session is cleared and the next app launch correctly shows the Login screen.


### PR DESCRIPTION
… of Firebase Auth before navigating to LoginActivity. This change prevents users from remaining logged in after reopening the app.