### PR TITLE
fix(lobby): host transfer, layout gaps, and padding on physical devices

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -18,12 +18,12 @@
           <targets>
             <Target type="DEFAULT_BOOT">
               <handle>
-                <DeviceId pluginId="PhysicalDevice" identifier="serial=R58RA34Z8NP" />
+                <DeviceId pluginId="PhysicalDevice" identifier="serial=097955433S106911" />
               </handle>
             </Target>
             <Target type="DEFAULT_BOOT">
               <handle>
-                <DeviceId pluginId="PhysicalDevice" identifier="serial=097955433S106911" />
+                <DeviceId pluginId="PhysicalDevice" identifier="serial=R58RA34Z8NP" />
               </handle>
             </Target>
             <Target type="DEFAULT_BOOT">

--- a/app/src/main/java/com/example/finalprojectandroiddev2/data/model/LobbyMember.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/data/model/LobbyMember.java
@@ -5,29 +5,34 @@ package com.example.finalprojectandroiddev2.data.model;
  *
  * Firebase path: lobbies/{roomCode}/members/{userId}/
  *   username  : String
+ *   gender    : String  (e.g. "Male", "Female", "Other")
  *   joinedAt  : long   (System.currentTimeMillis())
  *   isHost    : boolean
  */
 public class LobbyMember {
 
-    private String username;
-    private long joinedAt;
+    private String  username;
+    private String  gender;
+    private long    joinedAt;
     private boolean isHost;
 
     /** Required by Firebase deserializer. */
     public LobbyMember() {}
 
-    public LobbyMember(String username, long joinedAt, boolean isHost) {
+    public LobbyMember(String username, String gender, long joinedAt, boolean isHost) {
         this.username = username;
+        this.gender   = gender;
         this.joinedAt = joinedAt;
         this.isHost   = isHost;
     }
 
-    public String getUsername()  { return username; }
-    public long   getJoinedAt() { return joinedAt; }
-    public boolean isHost()      { return isHost; }
+    public String  getUsername() { return username; }
+    public String  getGender()   { return gender;   }
+    public long    getJoinedAt() { return joinedAt;  }
+    public boolean isHost()      { return isHost;    }
 
-    public void setUsername(String username)  { this.username = username; }
+    public void setUsername(String username) { this.username = username; }
+    public void setGender(String gender)     { this.gender   = gender;   }
     public void setJoinedAt(long joinedAt)   { this.joinedAt = joinedAt; }
-    public void setHost(boolean host)         { isHost = host; }
+    public void setHost(boolean host)        { isHost = host; }
 }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/base/BaseActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/base/BaseActivity.java
@@ -29,7 +29,16 @@ public abstract class BaseActivity extends AppCompatActivity {
     protected void applyEdgeToEdgeInsets(int rootViewId) {
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(rootViewId), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            // Convert 24dp to px — this is the layout's base padding defined in XML.
+            // We ADD it to the system bar insets because setPadding() replaces all padding;
+            // without this, horizontal padding (which has 0 system insets) would be wiped.
+            int dp24 = Math.round(24 * v.getContext().getResources().getDisplayMetrics().density);
+            v.setPadding(
+                    systemBars.left  + dp24,
+                    systemBars.top   + dp24,
+                    systemBars.right + dp24,
+                    systemBars.bottom + dp24
+            );
             return insets;
         });
     }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/MemberAdapter.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/MemberAdapter.java
@@ -3,18 +3,22 @@ package com.example.finalprojectandroiddev2.ui.lobby;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.finalprojectandroiddev2.R;
+import com.google.android.material.card.MaterialCardView;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Adapter for lobby member list. Displays username, host badge, and status indicator.
+ * Adapter for lobby member list.
+ * Each card shows the default avatar, member username, role (Host / Member),
+ * the host badge indicator, and an online status dot.
  */
 public class MemberAdapter extends RecyclerView.Adapter<MemberAdapter.ViewHolder> {
 
@@ -39,9 +43,33 @@ public class MemberAdapter extends RecyclerView.Adapter<MemberAdapter.ViewHolder
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         MemberItem item = members.get(position);
-        holder.textUsername.setText(item.username);
-        holder.textHostBadge.setVisibility(item.isHost ? View.VISIBLE : View.GONE);
-        // Status indicator visibility will be controlled by Firebase data in later phase
+
+        // Avatar
+        holder.imageAvatar.setImageResource(R.drawable.default_user_avatar3);
+
+        // Name line: "Jerome Avecilla (Host)" or "Jerome Avecilla (Member)"
+        String roleLabel = item.isHost
+                ? holder.itemView.getContext().getString(R.string.label_host)
+                : holder.itemView.getContext().getString(R.string.label_member);
+        holder.textUsername.setText(item.username + " (" + roleLabel + ")");
+
+        // Subtitle: gender (falls back to role label if gender is missing)
+        if (item.gender != null && !item.gender.isEmpty()) {
+            holder.textRole.setText(item.gender);
+        } else {
+            holder.textRole.setText(roleLabel);
+        }
+
+        // Current-user highlight: 2dp primary border, none otherwise
+        MaterialCardView card = (MaterialCardView) holder.itemView;
+        if (item.isCurrentUser) {
+            card.setStrokeWidth((int) (2 * holder.itemView.getContext()
+                    .getResources().getDisplayMetrics().density));
+        } else {
+            card.setStrokeWidth(0);
+        }
+
+        // Online dot
         holder.viewStatusIndicator.setVisibility(item.isOnline ? View.VISIBLE : View.GONE);
     }
 
@@ -51,31 +79,40 @@ public class MemberAdapter extends RecyclerView.Adapter<MemberAdapter.ViewHolder
     }
 
     static class ViewHolder extends RecyclerView.ViewHolder {
-        final TextView textUsername;
-        final TextView textHostBadge;
-        final View viewStatusIndicator;
+        final ImageView imageAvatar;
+        final TextView  textUsername;
+        final TextView  textRole;
+        final TextView  textHostBadge;
+        final View      viewStatusIndicator;
 
         ViewHolder(View itemView) {
             super(itemView);
-            textUsername = itemView.findViewById(R.id.text_username);
-            textHostBadge = itemView.findViewById(R.id.text_host_badge);
-            viewStatusIndicator = itemView.findViewById(R.id.view_status_indicator);
+            imageAvatar          = itemView.findViewById(R.id.image_avatar);
+            textUsername         = itemView.findViewById(R.id.text_username);
+            textRole             = itemView.findViewById(R.id.text_role);
+            textHostBadge        = itemView.findViewById(R.id.text_host_badge);
+            viewStatusIndicator  = itemView.findViewById(R.id.view_status_indicator);
         }
     }
 
     public static class MemberItem {
-        public final String username;
+        public final String  username;
+        public final String  gender;
         public final boolean isHost;
         public final boolean isOnline;
+        public final boolean isCurrentUser;
 
-        public MemberItem(String username, boolean isHost) {
-            this(username, isHost, true);
+        public MemberItem(String username, String gender, boolean isHost, boolean isCurrentUser) {
+            this(username, gender, isHost, true, isCurrentUser);
         }
 
-        public MemberItem(String username, boolean isHost, boolean isOnline) {
-            this.username = username;
-            this.isHost = isHost;
-            this.isOnline = isOnline;
+        public MemberItem(String username, String gender, boolean isHost, boolean isOnline,
+                          boolean isCurrentUser) {
+            this.username      = username;
+            this.gender        = gender;
+            this.isHost        = isHost;
+            this.isOnline      = isOnline;
+            this.isCurrentUser = isCurrentUser;
         }
     }
 }

--- a/app/src/main/res/layout/activity_create_lobby.xml
+++ b/app/src/main/res/layout/activity_create_lobby.xml
@@ -1,133 +1,193 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container_create_lobby"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_background"
-    android:fillViewport="true"
     tools:context=".ui.lobby.CreateLobbyActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
+
+    <!-- ── Room code card — top ─────────────────────────────────────────── -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_room_code"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:padding="24dp">
+        app:cardBackgroundColor="@color/color_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/card_room_code"
-            android:layout_width="0dp"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:cardBackgroundColor="@color/color_surface"
-            app:cardCornerRadius="16dp"
-            app:cardElevation="4dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="24dp">
 
+            <TextView
+                android:id="@+id/label_room_code"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/label_room_code"
+                android:textColor="@color/color_text_secondary"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/text_room_code"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="monospace"
+                android:textColor="@color/color_primary"
+                android:textIsSelectable="true"
+                android:textSize="32sp"
+                android:textStyle="bold"
+                tools:text="ABC123" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_share_room_code"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/btn_share_room_code"
+                android:textColor="@color/color_primary"
+                app:icon="@android:drawable/ic_menu_share"
+                app:iconGravity="textStart"
+                app:iconPadding="8dp"
+                app:iconTint="@color/color_primary" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- ── Leave Lobby — pinned to bottom of screen (never moves) ──────── -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_leave_lobby"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="@color/color_surface"
+        app:cardCornerRadius="50dp"
+        app:cardElevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_leave_lobby"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:text="@string/btn_leave_lobby"
+            android:textColor="@color/color_error"
+            android:textSize="16sp"
+            app:backgroundTint="@color/color_surface"
+            app:cornerRadius="50dp"
+            app:strokeColor="@color/color_error"
+            app:strokeWidth="2dp" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- ── Start Swiping — sits directly above Leave Lobby ─────────────── -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_start_swiping"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        app:cardBackgroundColor="@color/color_surface"
+        app:cardCornerRadius="50dp"
+        app:cardElevation="4dp"
+        app:layout_constraintBottom_toTopOf="@id/card_leave_lobby"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_start_swiping"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:enabled="false"
+            android:text="@string/btn_start_swiping"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:backgroundTint="@color/color_primary"
+            app:cornerRadius="50dp"
+            app:iconGravity="textStart"
+            app:iconPadding="16dp"
+            app:iconSize="24dp"
+            app:iconTint="@color/black" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- ── Members card — fills all space between room code and buttons ── -->
+    <!--    height=0dp stretches it; RecyclerView scrolls internally.      -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_members"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="16dp"
+        app:cardBackgroundColor="@color/color_surface"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="4dp"
+        app:layout_constraintBottom_toTopOf="@id/card_start_swiping"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/card_room_code">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <!-- Members header row -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="24dp"
-                android:gravity="center">
-
-                <TextView
-                    android:id="@+id/label_room_code"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/label_room_code"
-                    android:textColor="@color/color_text_secondary"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/text_room_code"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:textColor="@color/color_primary"
-                    android:textSize="32sp"
-                    android:textStyle="bold"
-                    android:fontFamily="monospace"
-                    android:textIsSelectable="true"
-                    tools:text="ABC123" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btn_share_room_code"
-                    style="@style/Widget.Material3.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="@string/btn_share_room_code"
-                    app:icon="@android:drawable/ic_menu_share"
-                    app:iconGravity="textStart"
-                    app:iconPadding="8dp"
-                    app:iconTint="@color/color_primary"
-                    android:textColor="@color/color_primary" />
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/card_members"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            app:cardBackgroundColor="@color/color_surface"
-            app:cardCornerRadius="16dp"
-            app:cardElevation="4dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/card_room_code">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="20dp">
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/label_members"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:text="@string/label_members"
                     android:textColor="@color/color_text_primary"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 
                 <TextView
-                    android:id="@+id/text_waiting_for_members"
+                    android:id="@+id/text_member_count"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/msg_waiting_for_members"
-                    android:textColor="@color/color_text_secondary"
-                    android:textSize="14sp" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/recycler_members"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:minHeight="80dp"
-                    android:nestedScrollingEnabled="false"
-                    tools:itemCount="0"
-                    tools:listitem="@layout/item_member" />
+                    android:textColor="@color/color_primary"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    tools:text="1 / 10" />
             </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btn_start_swiping"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:enabled="false"
-            android:text="@string/btn_start_swiping"
-            android:textSize="16sp"
-            app:backgroundTint="@color/color_primary"
-            app:cornerRadius="12dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/card_members" />
+            <!-- Shown until a second member joins -->
+            <TextView
+                android:id="@+id/text_waiting_for_members"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/msg_waiting_for_members"
+                android:textColor="@color/color_text_secondary"
+                android:textSize="14sp" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+            <!-- RecyclerView fills remaining card height and scrolls internally -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_members"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="12dp"
+                android:layout_weight="1"
+                android:nestedScrollingEnabled="true"
+                tools:itemCount="1"
+                tools:listitem="@layout/item_member" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_lobby.xml
+++ b/app/src/main/res/layout/activity_lobby.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container_lobby"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_background"
-    android:padding="24dp"
     tools:context=".ui.lobby.LobbyActivity">
 
+
+    <!-- ── Room code card — top ─────────────────────────────────────────── -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/card_room_code"
         android:layout_width="0dp"
@@ -23,9 +25,9 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center"
             android:orientation="vertical"
-            android:padding="20dp"
-            android:gravity="center">
+            android:padding="20dp">
 
             <TextView
                 android:id="@+id/label_room_code"
@@ -40,20 +42,106 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
+                android:fontFamily="monospace"
                 android:textColor="@color/color_primary"
+                android:textIsSelectable="true"
                 android:textSize="28sp"
                 android:textStyle="bold"
-                android:fontFamily="monospace"
-                android:textIsSelectable="true"
                 tools:text="ABC123" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_share_room_code"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/btn_share_room_code"
+                android:textColor="@color/color_primary"
+                app:icon="@android:drawable/ic_menu_share"
+                app:iconGravity="textStart"
+                app:iconPadding="8dp"
+                app:iconTint="@color/color_primary" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 
+    <!-- ── Leave Lobby — pinned to bottom of screen (never moves) ──────── -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_leave_lobby"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="@color/color_surface"
+        app:cardCornerRadius="50dp"
+        app:cardElevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_leave_lobby"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:text="@string/btn_leave_lobby"
+            android:textColor="@color/color_error"
+            android:textSize="16sp"
+            app:backgroundTint="@color/color_surface"
+            app:cornerRadius="50dp"
+            app:strokeColor="@color/color_error"
+            app:strokeWidth="2dp" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- ── Start Swiping — sits directly above Leave Lobby ─────────────── -->
+    <!--    GONE for non-hosts. Collapses upward, leave lobby stays put.   -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_start_swiping"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/color_surface"
+        app:cardCornerRadius="50dp"
+        app:cardElevation="4dp"
+        app:layout_constraintBottom_toTopOf="@id/card_leave_lobby"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_start_swiping"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:text="@string/btn_start_swiping"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:backgroundTint="@color/color_primary"
+            app:cornerRadius="50dp"
+            app:iconGravity="textStart"
+            app:iconPadding="16dp"
+            app:iconSize="24dp"
+            app:iconTint="@color/black" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- ── Progress indicator — sits above Start Swiping ───────────────── -->
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progress_loading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:visibility="gone"
+        app:indicatorColor="@color/color_primary"
+        app:layout_constraintBottom_toTopOf="@id/card_start_swiping"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:trackColor="@color/color_surface"
+        tools:visibility="visible" />
+
+    <!-- ── Members card — fills all space between room code and buttons ── -->
+    <!--    height=0dp stretches it; RecyclerView scrolls internally.      -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/card_members"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="24dp"
+        android:layout_marginBottom="16dp"
         app:cardBackgroundColor="@color/color_surface"
         app:cardCornerRadius="16dp"
         app:cardElevation="4dp"
@@ -68,70 +156,44 @@
             android:orientation="vertical"
             android:padding="20dp">
 
-            <TextView
-                android:id="@+id/label_members"
-                android:layout_width="wrap_content"
+            <!-- Members header row -->
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/label_members"
-                android:textColor="@color/color_text_primary"
-                android:textSize="16sp"
-                android:textStyle="bold" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
+                <TextView
+                    android:id="@+id/label_members"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/label_members"
+                    android:textColor="@color/color_text_primary"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/text_member_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/color_primary"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    tools:text="1 / 10" />
+            </LinearLayout>
+
+            <!-- RecyclerView fills remaining card height and scrolls internally -->
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recycler_members"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_marginTop="12dp"
                 android:layout_weight="1"
-                android:nestedScrollingEnabled="false"
+                android:nestedScrollingEnabled="true"
                 tools:itemCount="3"
                 tools:listitem="@layout/item_member" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.progressindicator.LinearProgressIndicator
-        android:id="@+id/progress_loading"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:visibility="gone"
-        app:indicatorColor="@color/color_primary"
-        app:trackColor="@color/color_surface"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/card_members"
-        tools:visibility="visible" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_start_swiping"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:text="@string/btn_start_swiping"
-        android:textSize="16sp"
-        android:visibility="gone"
-        app:backgroundTint="@color/color_primary"
-        app:cornerRadius="12dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/progress_loading"
-        tools:visibility="visible" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_leave_lobby"
-        style="@style/Widget.Material3.Button.OutlinedButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/btn_leave_lobby"
-        android:textSize="16sp"
-        app:strokeColor="@color/color_error"
-        app:strokeWidth="2dp"
-        app:cornerRadius="12dp"
-        android:textColor="@color/color_error"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_start_swiping" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_member.xml
+++ b/app/src/main/res/layout/item_member.xml
@@ -1,55 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:gravity="center_vertical"
-    android:padding="12dp">
-
-    <ImageView
-        android:id="@+id/image_avatar"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:background="@drawable/bg_avatar_placeholder"
-        android:contentDescription="@string/label_avatar"
-        android:scaleType="centerCrop" />
-
-    <TextView
-        android:id="@+id/text_username"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_marginStart="12dp"
-        android:textColor="@color/color_text_primary"
-        android:textSize="16sp"
-        tools:text="Member Name" />
+    android:layout_marginBottom="10dp"
+    app:cardBackgroundColor="@color/color_background"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="2dp"
+    app:strokeColor="@color/color_primary"
+    app:strokeWidth="0dp">
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:padding="14dp">
 
-        <View
-            android:id="@+id/view_status_indicator"
-            android:layout_width="8dp"
-            android:layout_height="8dp"
-            android:layout_marginEnd="8dp"
-            android:background="@drawable/bg_status_online"
-            android:visibility="gone"
-            tools:visibility="visible" />
+        <!-- Avatar -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="0dp"
+            app:strokeWidth="0dp">
 
-        <TextView
-            android:id="@+id/text_host_badge"
+            <ImageView
+                android:id="@+id/image_avatar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/label_avatar"
+                android:scaleType="centerCrop"
+                android:src="@drawable/default_user_avatar3" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- Name + Role -->
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="14dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/text_username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/color_text_primary"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                android:maxLines="1"
+                android:ellipsize="end"
+                tools:text="Guest User" />
+
+            <TextView
+                android:id="@+id/text_role"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="@color/color_text_secondary"
+                android:textSize="12sp"
+                tools:text="Member" />
+        </LinearLayout>
+
+        <!-- Host badge + online indicator -->
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="@color/color_surface"
-            android:padding="8dp"
-            android:text="@string/label_host"
-            android:textColor="@color/color_primary"
-            android:textSize="12sp"
-            android:visibility="gone"
-            tools:visibility="visible" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <View
+                android:id="@+id/view_status_indicator"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_marginEnd="8dp"
+                android:background="@drawable/bg_status_online"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/text_host_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/color_surface"
+                android:padding="8dp"
+                android:text="@string/label_host"
+                android:textColor="@color/color_primary"
+                android:textSize="12sp"
+                android:visibility="gone"
+                tools:visibility="visible" />
+        </LinearLayout>
+
     </LinearLayout>
-</LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="label_room_code">Room Code</string>
     <string name="label_members">Members</string>
     <string name="label_host">Host</string>
+    <string name="label_member">Member</string>
+
     <string name="btn_share_room_code">Share Room Code</string>
     <string name="btn_start_swiping">Start Swiping</string>
     <string name="msg_waiting_for_members">Waiting for members to join…</string>
@@ -93,6 +95,7 @@
     <string name="error_invalid_code">Please enter a valid 6-character room code.</string>
     <string name="msg_generating_code">Generating room code…</string>
     <string name="msg_leave_lobby_confirm">Leave this lobby?</string>
+    <string name="share_room_code_message">Join my CineMatch lobby! Room code: %s</string>
 
 
     <!-- Swiping -->


### PR DESCRIPTION
- Fix host transfer never firing: removeMember() was reading/writing "isHost" but createLobby/joinLobby write the key as "host" (Java-bean getter convention). Corrected all reads and writes to use "host".

- Add createdBy field to lobby root on creation (stores original creator UID — stable, never changes on host transfer).

- LobbyActivity: detect host promotion at runtime via onMemberChanged; show Start Swiping button and wire its listener without restarting the activity.

- Fix button gap growing as members leave: replaced ScrollView + fillViewport with a full-height ConstraintLayout. card_leave_lobby is pinned to parent bottom; card_start_swiping collapses upward when GONE; card_members fills remaining space with height=0dp; RecyclerView scrolls internally.

- Fix horizontal padding stripped on physical devices: BaseActivity .applyEdgeToEdgeInsets() was calling setPadding() which overwrites XML padding. Now adds 24dp base padding on top of system bar insets. Removed redundant android:padding from both lobby layout XMLs.

- Add share_room_code_message string resource for LobbyActivity.