### PR TITLE
feat(lobby): add "Tap to return to lobby" banner + fix back-press rol…

### DIFF
--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/CreateLobbyActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/CreateLobbyActivity.java
@@ -15,6 +15,7 @@ import com.example.finalprojectandroiddev2.ui.base.BaseActivity;
 import com.example.finalprojectandroiddev2.ui.home.HomeActivity;
 import com.example.finalprojectandroiddev2.ui.swiping.SwipingActivity;
 import com.example.finalprojectandroiddev2.utils.Constants;
+import com.example.finalprojectandroiddev2.utils.LobbyPrefs;
 import com.example.finalprojectandroiddev2.utils.Logger;
 import com.example.finalprojectandroiddev2.utils.RoomCodeGenerator;
 import com.google.android.material.button.MaterialButton;
@@ -159,6 +160,8 @@ public class CreateLobbyActivity extends BaseActivity {
                 new FirebaseRepository.SimpleCallback() {
                     @Override public void onSuccess() {
                         Logger.d(TAG, "Lobby created: " + roomCode);
+                        // Persist room code so HomeActivity can show the return banner
+                        LobbyPrefs.saveActiveRoomCode(CreateLobbyActivity.this, roomCode);
                         attachFirebaseListeners();
                     }
                     @Override public void onFailure(String message) {
@@ -245,12 +248,13 @@ public class CreateLobbyActivity extends BaseActivity {
 
     // ── Back / Leave ───────────────────────────────────────────────────────────
 
-    @Override
-    public void onBackPressed() {
-        leaveLobby();
-    }
+    // Back is intentionally NOT overridden: pressing Back just backgrounds the activity.
+    // The return banner in HomeActivity lets the user come back. Only the Leave button
+    // triggers removal from Firebase.
 
     private void leaveLobby() {
+        // Clear the stored room code — user is intentionally leaving
+        LobbyPrefs.clearActiveRoomCode(this);
         if (roomCode != null) {
             firebaseRepo.removeMember(roomCode, currentUserId, null);
         }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/LobbyActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/LobbyActivity.java
@@ -15,6 +15,7 @@ import com.example.finalprojectandroiddev2.ui.base.BaseActivity;
 import com.example.finalprojectandroiddev2.ui.home.HomeActivity;
 import com.example.finalprojectandroiddev2.ui.swiping.SwipingActivity;
 import com.example.finalprojectandroiddev2.utils.Constants;
+import com.example.finalprojectandroiddev2.utils.LobbyPrefs;
 import com.example.finalprojectandroiddev2.utils.Logger;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
@@ -75,6 +76,9 @@ public class LobbyActivity extends BaseActivity {
                 : "";
 
         firebaseRepo = FirebaseRepository.getInstance();
+
+        // Persist room code so HomeActivity shows the return banner if user presses Back
+        LobbyPrefs.saveActiveRoomCode(this, roomCode);
 
         bindViews();
         setupRecyclerView();
@@ -233,6 +237,8 @@ public class LobbyActivity extends BaseActivity {
     }
 
     private void leaveLobby() {
+        // Clear the stored room code — user is intentionally leaving
+        LobbyPrefs.clearActiveRoomCode(this);
         firebaseRepo.removeMember(roomCode, currentUserId, new FirebaseRepository.SimpleCallback() {
             @Override public void onSuccess() {
                 navigateToHome();

--- a/app/src/main/java/com/example/finalprojectandroiddev2/utils/LobbyPrefs.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/utils/LobbyPrefs.java
@@ -1,0 +1,43 @@
+package com.example.finalprojectandroiddev2.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Thin helper for persisting the user's active lobby room code across back-presses
+ * and app restarts.
+ *
+ * Written when a lobby is created or joined successfully.
+ * Cleared only when the user explicitly taps "Leave Lobby".
+ * HomeActivity reads this in onResume() and verifies membership with Firebase.
+ */
+public final class LobbyPrefs {
+
+    private static final String PREF_FILE     = "lobby_prefs";
+    private static final String KEY_ROOM_CODE = "active_room_code";
+
+    private LobbyPrefs() {}
+
+    /** Persist the room code the user is currently in. */
+    public static void saveActiveRoomCode(Context ctx, String roomCode) {
+        prefs(ctx).edit().putString(KEY_ROOM_CODE, roomCode).apply();
+    }
+
+    /**
+     * Returns the stored room code, or {@code null} if the user is not in any lobby.
+     */
+    public static String getActiveRoomCode(Context ctx) {
+        String code = prefs(ctx).getString(KEY_ROOM_CODE, null);
+        return (code != null && !code.isEmpty()) ? code : null;
+    }
+
+    /** Call when the user explicitly leaves a lobby via "Leave Lobby" button. */
+    public static void clearActiveRoomCode(Context ctx) {
+        prefs(ctx).edit().remove(KEY_ROOM_CODE).apply();
+    }
+
+    private static SharedPreferences prefs(Context ctx) {
+        return ctx.getApplicationContext()
+                  .getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE);
+    }
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -8,12 +8,53 @@
     tools:context=".ui.home.HomeActivity">
 
     <!-- ── Main content ── -->
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/container_home"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/content_wrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/color_background"
-        android:fillViewport="true">
+        android:background="@color/color_background">
+
+        <!-- Sticky return-to-lobby banner (hidden until the user is in an active lobby) -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/banner_return_lobby"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:cardBackgroundColor="?attr/colorPrimary"
+            app:cardCornerRadius="0dp"
+            app:cardElevation="6dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal"
+                android:paddingHorizontal="20dp"
+                android:paddingVertical="12dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/banner_return_lobby"
+                    android:textColor="?attr/colorOnPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/container_home"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/color_background"
+            android:fillViewport="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/banner_return_lobby">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -246,6 +287,8 @@
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <!-- ── Sidebar (slides from END / right) ── -->
     <include

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="msg_generating_code">Generating room code…</string>
     <string name="msg_leave_lobby_confirm">Leave this lobby?</string>
     <string name="share_room_code_message">Join my CineMatch lobby! Room code: %s</string>
+    <string name="banner_return_lobby">↩  Tap to return to lobby</string>
 
 
     <!-- Swiping -->


### PR DESCRIPTION
…e override

- Add LobbyPrefs.java (SharedPreferences helper) to persist the active room code across Back presses and app restarts.
- FirebaseRepository: add MemberLoadCallback interface and getMember() single-read method. Reads lobbies/{roomCode}/members/{userId} to verify membership and get the live isHost value.
- CreateLobbyActivity: remove onBackPressed() override — Back no longer calls removeMember(). Only the Leave Lobby button removes the user from Firebase. Save room code to LobbyPrefs on lobby creation; clear on explicit leave.
- LobbyActivity: save room code to LobbyPrefs in onCreate (covers joiners); clear on explicit leave.
- activity_home.xml: wrap NestedScrollView in a ConstraintLayout (content_wrapper). Add sticky MaterialCardView banner pinned to top, hidden by default; scroll content constrained below it.
- HomeActivity: target content_wrapper for edge-to-edge insets. On onResume(), check LobbyPrefs → call getMember() → show banner if still a member (with live isHost), hide and clear SP if not. Banner tap navigates to LobbyActivity with correct role.
- strings.xml: add banner_return_lobby string.