### PR TITLE
Fix: "Tap to Return to Lobby" Banner Incorrectly Shown After Session …

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -18,17 +18,12 @@
           <targets>
             <Target type="DEFAULT_BOOT">
               <handle>
-                <DeviceId pluginId="PhysicalDevice" identifier="serial=097955433S106911" />
+                <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\jerom\.android\avd\Medium_Phone.avd" />
               </handle>
             </Target>
             <Target type="DEFAULT_BOOT">
               <handle>
                 <DeviceId pluginId="PhysicalDevice" identifier="serial=R58RA34Z8NP" />
-              </handle>
-            </Target>
-            <Target type="DEFAULT_BOOT">
-              <handle>
-                <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\jerom\.android\avd\Medium_Phone.avd" />
               </handle>
             </Target>
           </targets>

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/home/HomeActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/home/HomeActivity.java
@@ -208,8 +208,14 @@ public class HomeActivity extends BaseActivity {
                                           Response<MovieListResponse> response) {
                         if (response.isSuccessful() && response.body() != null) {
                             List<Movie> movies = response.body().getResults();
-                            if (movies != null && !movies.isEmpty()) {
-                                trendingAdapter.setMovies(movies);
+                            // if (movies != null && !movies.isEmpty()) {
+                            //     trendingAdapter.setMovies(movies);
+                            // }
+                            if (movies != null && movies.size() > 1) {
+                                // Start with item 2 onward, then append item 1 at the end
+                                List<Movie> reordered = new ArrayList<>(movies.subList(1, movies.size()));
+                                reordered.addAll(movies.subList(0, 1));
+                                trendingAdapter.setMovies(reordered);
                             }
                         }
                     }
@@ -243,10 +249,10 @@ public class HomeActivity extends BaseActivity {
                                           Response<MovieListResponse> response) {
                         if (response.isSuccessful() && response.body() != null) {
                             List<Movie> movies = response.body().getResults();
-                            if (movies != null && movies.size() > 10) {
-                                // Start with item 11 onward, then append items 1–10 at the end
-                                List<Movie> reordered = new ArrayList<>(movies.subList(10, movies.size()));
-                                reordered.addAll(movies.subList(0, 10));
+                            if (movies != null && movies.size() > 9) {
+                                // Start with item 10 onward, then append items 1–9 at the end
+                                List<Movie> reordered = new ArrayList<>(movies.subList(9, movies.size()));
+                                reordered.addAll(movies.subList(0, 9));
                                 topRatedAdapter.setMovies(reordered);
                             }
                         }
@@ -280,10 +286,10 @@ public class HomeActivity extends BaseActivity {
                                           Response<MovieListResponse> response) {
                         if (response.isSuccessful() && response.body() != null) {
                             List<Movie> movies = response.body().getResults();
-                            if (movies != null && movies.size() > 14) {
-                                // Start from item 15 onward, then append items 1–14 at the end
-                                List<Movie> reordered = new ArrayList<>(movies.subList(14, movies.size()));
-                                reordered.addAll(movies.subList(0, 14));
+                            if (movies != null && movies.size() > 15) {
+                                // Start from item 16 onward, then append items 1–15 at the end
+                                List<Movie> reordered = new ArrayList<>(movies.subList(15, movies.size()));
+                                reordered.addAll(movies.subList(0, 15));
                                 popularAdapter.setMovies(reordered);
                             }
                         }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java
@@ -8,6 +8,7 @@ import androidx.viewpager2.widget.ViewPager2;
 import com.example.finalprojectandroiddev2.R;
 import com.example.finalprojectandroiddev2.ui.base.BaseActivity;
 import com.example.finalprojectandroiddev2.ui.home.HomeActivity;
+import com.example.finalprojectandroiddev2.utils.LobbyPrefs;
 
 /**
  * Swiping screen: displays movie cards for swiping Yes/No.
@@ -21,6 +22,10 @@ public class SwipingActivity extends BaseActivity {
         setContentView(R.layout.activity_swiping);
         applyEdgeToEdgeInsets(R.id.container_swiping);
 
+        // Session has started — clear the active lobby so the "Tap to return to lobby"
+        // banner never appears on the Home screen while/after swiping.
+        LobbyPrefs.clearActiveRoomCode(this);
+
         ViewPager2 viewPagerMovies = findViewById(R.id.viewpager_movies);
         // ViewPager2 adapter will be set when TMDB movies are fetched
         // For now, ViewPager2 is configured but empty
@@ -28,6 +33,7 @@ public class SwipingActivity extends BaseActivity {
         // Navigate to HomeActivity (not LobbyActivity) — the lobby session is already
         // complete at this point and LobbyActivity requires a room_code extra to function.
         findViewById(R.id.btn_exit_session).setOnClickListener(v -> {
+            LobbyPrefs.clearActiveRoomCode(this);
             startActivity(new Intent(this, HomeActivity.class)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
             finish();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sun Feb 22 18:23:44 PST 2026
 networkTimeout=10000
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 validateDistributionUrl=true
 zipStorePath=wrapper/dists

--- a/notes/LOGS_CHANGES.md
+++ b/notes/LOGS_CHANGES.md
@@ -1,5 +1,23 @@
 # CineMatch – Log of Changes
 
+## 2026-02-23 – Fix: "Tap to Return to Lobby" Banner Incorrectly Shown After Session Exit
+
+**What:** The "Tap to return to lobby" banner was appearing on the Home screen after a user clicked "Exit Session" in `SwipingActivity`. This was wrong because once a session has started (host clicked "Start Swiping"), there is no lobby to return to — the user has intentionally left the session.
+
+**Root cause:** `SwipingActivity` did not call `LobbyPrefs.clearActiveRoomCode()` when navigating away. The room code saved during the lobby waiting phase was still in SharedPreferences, so `HomeActivity.checkActiveLobby()` found it and showed the banner.
+
+**Fix — `SwipingActivity.java`:**
+
+- Added `LobbyPrefs.clearActiveRoomCode(this)` in `onCreate()` — clears the room code the moment swiping begins. This ensures the banner never appears even if the user presses Back (instead of using Exit button).
+- Also added the same clear call inside the `btn_exit_session` click listener as a safety guard.
+
+**Behaviour summary:**
+
+- Banner **shows** → only while in the lobby waiting room (session not yet started). Users can press Back to browse the Home screen and tap the banner to jump back in.
+- Banner **hidden** → as soon as `SwipingActivity` starts (host has clicked "Start Swiping"), the room code is cleared for all participants.
+
+---
+
 ## 2026-02-23 – Feature: "Tap to Return to Lobby" Sticky Banner + Back-Press Fix
 
 **What:** A primary-colored sticky banner is now shown at the top of the Home screen whenever the current user is still a member of an active lobby. Tapping it navigates back to `LobbyActivity` with their **live role** (host or member) read from Firebase — so re-joining as the wrong role is no longer possible.


### PR DESCRIPTION
- Banner show only while in the lobby waiting room (session not yet started). Users can press Back to browse the Home screen and tap the banner to jump back in.
- Banner hidden as soon as swiping activity or session starts (host has clicked "Start Swiping"), the room code is cleared for all participants.