### PR TITLE
feat(swiping): room-code-seeded TMDB page, locked swipe input, card U…

### DIFF
--- a/app/src/main/java/com/example/finalprojectandroiddev2/data/api/TmdbApiService.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/data/api/TmdbApiService.java
@@ -26,8 +26,10 @@ public interface TmdbApiService {
     Call<MovieListResponse> getTrendingMovies(
             @Path("time_window") String timeWindow,
             @Query("language") String language,
+            @Query("page") int page,
             @Header("Authorization") String bearerToken
     );
+
 
     /**
      * GET /movie/popular

--- a/app/src/main/java/com/example/finalprojectandroiddev2/data/model/Movie.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/data/model/Movie.java
@@ -57,4 +57,16 @@ public class Movie {
     public List<Integer> getGenreIds() { return genreIds; }
 
     public double getPopularity() { return popularity; }
+
+    // ── Setters (used when rebuilding Movie from Firebase) ────────────────────
+
+    public void setId(int id)                        { this.id           = id;          }
+    public void setTitle(String title)               { this.title        = title;       }
+    public void setPosterPath(String posterPath)     { this.posterPath   = posterPath;  }
+    public void setBackdropPath(String backdropPath) { this.backdropPath = backdropPath;}
+    public void setOverview(String overview)         { this.overview     = overview;    }
+    public void setVoteAverage(double voteAverage)   { this.voteAverage  = voteAverage; }
+    public void setReleaseDate(String releaseDate)   { this.releaseDate  = releaseDate; }
+    public void setGenreIds(List<Integer> genreIds)  { this.genreIds     = genreIds;    }
 }
+

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/home/HomeActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/home/HomeActivity.java
@@ -201,7 +201,7 @@ public class HomeActivity extends BaseActivity {
         String bearer = "Bearer " + BuildConfig.TMDB_READ_ACCESS_TOKEN;
 
         TmdbApiService api = TmdbApiClient.getService();
-        api.getTrendingMovies("day", "en-US", bearer)
+        api.getTrendingMovies("day", "en-US", 1, bearer)
                 .enqueue(new Callback<MovieListResponse>() {
                     @Override
                     public void onResponse(Call<MovieListResponse> call,

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/LobbyActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/LobbyActivity.java
@@ -212,8 +212,11 @@ public class LobbyActivity extends BaseActivity {
 
     private void startSwipingSession() {
         btnStartSwiping.setEnabled(false);
+        // Set lobby status to "swiping" — the status listener fires on all devices
+        // (including this host) and each device navigates to SwipingActivity independently.
+        // Each device fetches TMDB page 1 directly — deterministic, so all users
+        // see identical movies without any Firebase coordination needed.
         firebaseRepo.setLobbyStatus(roomCode, Constants.LOBBY_STATUS_SWIPING);
-        // Status listener above will fire for all devices (including host)
         sessionStarted = true;
         navigateToSwiping();
     }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/MovieCardAdapter.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/MovieCardAdapter.java
@@ -1,0 +1,205 @@
+package com.example.finalprojectandroiddev2.ui.swiping;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.example.finalprojectandroiddev2.R;
+import com.example.finalprojectandroiddev2.data.model.Movie;
+import com.example.finalprojectandroiddev2.utils.Constants;
+import com.google.android.material.chip.Chip;
+import com.google.android.material.chip.ChipGroup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * ViewPager2 adapter that displays full-screen swipeable movie cards.
+ *
+ * Each card has two overlay states:
+ *   COLLAPSED (default) — shows movie title + release date over a gradient scrim
+ *   EXPANDED  (on tap)  — additionally shows overview + genre chips
+ *
+ * Tapping the card toggles between the two states.
+ */
+public class MovieCardAdapter extends RecyclerView.Adapter<MovieCardAdapter.MovieCardViewHolder> {
+
+    // ── TMDB Genre ID → Name (standard TMDB movie genre list) ─────────────────
+    private static final Map<Integer, String> GENRE_MAP = new HashMap<>();
+    static {
+        GENRE_MAP.put(28,    "Action");
+        GENRE_MAP.put(12,    "Adventure");
+        GENRE_MAP.put(16,    "Animation");
+        GENRE_MAP.put(35,    "Comedy");
+        GENRE_MAP.put(80,    "Crime");
+        GENRE_MAP.put(99,    "Documentary");
+        GENRE_MAP.put(18,    "Drama");
+        GENRE_MAP.put(10751, "Family");
+        GENRE_MAP.put(14,    "Fantasy");
+        GENRE_MAP.put(36,    "History");
+        GENRE_MAP.put(27,    "Horror");
+        GENRE_MAP.put(10402, "Music");
+        GENRE_MAP.put(9648,  "Mystery");
+        GENRE_MAP.put(10749, "Romance");
+        GENRE_MAP.put(878,   "Sci-Fi");
+        GENRE_MAP.put(10770, "TV Movie");
+        GENRE_MAP.put(53,    "Thriller");
+        GENRE_MAP.put(10752, "War");
+        GENRE_MAP.put(37,    "Western");
+    }
+
+    // ── Data ──────────────────────────────────────────────────────────────────
+
+    private final List<Movie> movies = new ArrayList<>();
+
+    /** Replace the current list and redraw all cards. */
+    public void setMovies(List<Movie> newMovies) {
+        movies.clear();
+        if (newMovies != null) movies.addAll(newMovies);
+        notifyDataSetChanged();
+    }
+
+    // ── Adapter ───────────────────────────────────────────────────────────────
+
+    @NonNull
+    @Override
+    public MovieCardViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_movie_card, parent, false);
+        return new MovieCardViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull MovieCardViewHolder holder, int position) {
+        holder.bind(movies.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return movies.size();
+    }
+
+    // ── ViewHolder ────────────────────────────────────────────────────────────
+
+    static class MovieCardViewHolder extends RecyclerView.ViewHolder {
+
+        private final ImageView  ivPoster;
+        private final TextView   tvTitle;
+        private final TextView   tvReleaseDate;
+        private final TextView   tvRating;
+        // Expanded-only views
+        private final TextView   tvOverview;
+        private final ChipGroup  chipGroupGenres;
+
+        /** Tracks whether the card is in its expanded state. Starts true — expanded by default. */
+        private boolean isExpanded = true;
+
+        MovieCardViewHolder(@NonNull View itemView) {
+            super(itemView);
+            ivPoster        = itemView.findViewById(R.id.image_poster);
+            tvTitle         = itemView.findViewById(R.id.text_movie_title);
+            tvReleaseDate   = itemView.findViewById(R.id.text_movie_release_date);
+            tvRating        = itemView.findViewById(R.id.text_movie_rating);
+            tvOverview      = itemView.findViewById(R.id.text_movie_overview);
+            chipGroupGenres = itemView.findViewById(R.id.chip_group_card_genres);
+        }
+
+        void bind(Movie movie) {
+            // Default to expanded state whenever card is (re)bound
+            isExpanded = true;
+            setExpandedState(true);
+
+            // Title
+            tvTitle.setText(movie.getTitle() != null ? movie.getTitle() : "");
+
+            // Rating — top-right badge
+            tvRating.setText(String.format(Locale.getDefault(), "⭐ %.1f", movie.getVoteAverage()));
+
+            // Release date
+            tvReleaseDate.setText(formatReleaseDate(movie.getReleaseDate()));
+
+            // Overview
+            tvOverview.setText(movie.getOverview() != null ? movie.getOverview() : "");
+
+            // Genre chips
+            buildGenreChips(itemView.getContext(), movie);
+
+            // Image — prefer backdrop (wider aspect ratio), fall back to poster
+            String imagePath;
+            if (movie.getBackdropPath() != null && !movie.getBackdropPath().isEmpty()) {
+                imagePath = Constants.TMDB_IMAGE_BASE_URL + movie.getBackdropPath();
+            } else if (movie.getPosterPath() != null && !movie.getPosterPath().isEmpty()) {
+                imagePath = Constants.TMDB_IMAGE_BASE_URL + movie.getPosterPath();
+            } else {
+                imagePath = null;
+            }
+
+            Glide.with(itemView.getContext())
+                    .load(imagePath)
+                    .centerCrop()
+                    .placeholder(R.color.color_surface)
+                    .error(R.color.color_surface)
+                    .into(ivPoster);
+
+            // Toggle expanded / collapsed on card tap
+            itemView.setOnClickListener(v -> {
+                isExpanded = !isExpanded;
+                setExpandedState(isExpanded);
+            });
+        }
+
+        /** Show or hide the expanded-only views (overview + genres). */
+        private void setExpandedState(boolean expanded) {
+            int visibility = expanded ? View.VISIBLE : View.GONE;
+            tvOverview.setVisibility(visibility);
+            chipGroupGenres.setVisibility(visibility);
+        }
+
+        /** Populates the ChipGroup with genre names resolved from genreIds. */
+        private void buildGenreChips(Context ctx, Movie movie) {
+            chipGroupGenres.removeAllViews();
+            if (movie.getGenreIds() == null) return;
+
+            for (int id : movie.getGenreIds()) {
+                String name = GENRE_MAP.get(id);
+                if (name == null) continue;
+
+                Chip chip = new Chip(ctx);
+                chip.setText(name);
+                chip.setClickable(false);
+                chip.setCheckable(false);
+                chip.setChipBackgroundColorResource(R.color.color_surface);
+                chip.setTextColor(ctx.getColor(R.color.color_text_primary));
+                chip.setTextSize(11f);
+                chipGroupGenres.addView(chip);
+            }
+        }
+
+        /**
+         * Converts raw TMDB date "YYYY-MM-DD" to a friendly "MMM yyyy" string.
+         * e.g. "2026-02-25" → "Feb 2026". Returns "—" if null, empty, or unparseable.
+         */
+        private String formatReleaseDate(String rawDate) {
+            if (rawDate == null || rawDate.isEmpty()) return "—";
+            try {
+                java.text.SimpleDateFormat inputFmt  = new java.text.SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+                java.text.SimpleDateFormat outputFmt = new java.text.SimpleDateFormat("MMM yyyy",   Locale.getDefault());
+                java.util.Date date = inputFmt.parse(rawDate);
+                return date != null ? outputFmt.format(date) : rawDate;
+            } catch (java.text.ParseException e) {
+                return rawDate; // fallback to raw string
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java
@@ -2,19 +2,44 @@ package com.example.finalprojectandroiddev2.ui.swiping;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Toast;
 
+import androidx.viewpager2.widget.CompositePageTransformer;
+import androidx.viewpager2.widget.MarginPageTransformer;
 import androidx.viewpager2.widget.ViewPager2;
 
+import com.example.finalprojectandroiddev2.BuildConfig;
 import com.example.finalprojectandroiddev2.R;
+import com.example.finalprojectandroiddev2.data.api.TmdbApiClient;
+import com.example.finalprojectandroiddev2.data.model.Movie;
+import com.example.finalprojectandroiddev2.data.model.MovieListResponse;
 import com.example.finalprojectandroiddev2.ui.base.BaseActivity;
 import com.example.finalprojectandroiddev2.ui.home.HomeActivity;
+import com.example.finalprojectandroiddev2.ui.lobby.LobbyActivity;
 import com.example.finalprojectandroiddev2.utils.LobbyPrefs;
+import com.example.finalprojectandroiddev2.utils.Logger;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
- * Swiping screen: displays movie cards for swiping Yes/No.
- * ViewPager2 adapter, swipe gestures, and Firebase vote sync will be added in a later phase.
+ * Swiping screen: displays a full-screen ViewPager2 deck of movie cards.
+ *
+ * Every device fetches the same TMDB endpoint (trending/day, page 1) directly.
+ * Because page 1 is deterministic and identical for all clients at a given moment,
+ * all users in the same lobby see the same movies in the same order — no Firebase
+ * coordination required for the movie list itself.
  */
 public class SwipingActivity extends BaseActivity {
+
+    private static final String TAG = "CineMatch.Swiping";
+
+    private ViewPager2       viewPagerMovies;
+    private MovieCardAdapter movieCardAdapter;
+    private String           roomCode;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,19 +51,129 @@ public class SwipingActivity extends BaseActivity {
         // banner never appears on the Home screen while/after swiping.
         LobbyPrefs.clearActiveRoomCode(this);
 
-        ViewPager2 viewPagerMovies = findViewById(R.id.viewpager_movies);
-        // ViewPager2 adapter will be set when TMDB movies are fetched
-        // For now, ViewPager2 is configured but empty
+        roomCode = getIntent().getStringExtra(LobbyActivity.EXTRA_ROOM_CODE);
 
-        // Navigate to HomeActivity (not LobbyActivity) — the lobby session is already
-        // complete at this point and LobbyActivity requires a room_code extra to function.
+        bindViews();
+        setupViewPager();
+        setupButtons();
+        fetchMovies();
+    }
+
+    // ── Views ──────────────────────────────────────────────────────────────────
+
+    private void bindViews() {
+        viewPagerMovies = findViewById(R.id.viewpager_movies);
+    }
+
+    // ── ViewPager2 setup ───────────────────────────────────────────────────────
+
+    private void setupViewPager() {
+        movieCardAdapter = new MovieCardAdapter();
+        viewPagerMovies.setAdapter(movieCardAdapter);
+
+        // Disable free swiping — cards only advance via the Yes / No buttons.
+        // This ensures every card transition is a deliberate vote, not an accidental swipe.
+        // (Phase 7.2 will add swipe-left = No / swipe-right = Yes touch shortcuts on the card itself.)
+        viewPagerMovies.setUserInputEnabled(false);
+
+        viewPagerMovies.setOffscreenPageLimit(2);
+
+        CompositePageTransformer transformer = new CompositePageTransformer();
+        transformer.addTransformer(new MarginPageTransformer(24));
+        transformer.addTransformer((page, position) -> {
+            float absPos = Math.abs(position);
+            page.setScaleY(1f - absPos * 0.08f);
+            page.setAlpha(1f  - absPos * 0.3f);
+        });
+        viewPagerMovies.setPageTransformer(transformer);
+    }
+
+    // ── Buttons ────────────────────────────────────────────────────────────────
+
+    private void setupButtons() {
+        // Yes / No — vote logic will be wired in Phase 7.2
+        findViewById(R.id.btn_swipe_yes).setOnClickListener(v -> handleYes());
+        findViewById(R.id.btn_swipe_no).setOnClickListener(v  -> handleNo());
+
+        // Exit session
         findViewById(R.id.btn_exit_session).setOnClickListener(v -> {
             LobbyPrefs.clearActiveRoomCode(this);
             startActivity(new Intent(this, HomeActivity.class)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
             finish();
         });
+    }
 
-        // Yes/No button click handlers will be added when swipe logic is implemented
+    // ── Yes / No stubs (Phase 7.2) ─────────────────────────────────────────────
+
+    private void handleYes() {
+        // TODO Phase 7.2 — save vote to Firebase, then advance card
+        advanceCard();
+    }
+
+    private void handleNo() {
+        // TODO Phase 7.2 — discard and advance card
+        advanceCard();
+    }
+
+    /** Move ViewPager2 to the next card with a smooth scroll. */
+    private void advanceCard() {
+        int next = viewPagerMovies.getCurrentItem() + 1;
+        if (next < movieCardAdapter.getItemCount()) {
+            viewPagerMovies.setCurrentItem(next, true);
+        }
+    }
+
+    // ── TMDB fetch ─────────────────────────────────────────────────────────────
+
+    /**
+     * Fetches trending movies (day) from TMDB.
+     *
+     * The page number is derived deterministically from the room code so that
+     * every device in the same lobby always hits the same page — guaranteeing
+     * an identical, ordered movie list for all users without any server coordination.
+     *
+     * Different room codes → different pages (1-100) → session variety.
+     * No shuffling — TMDB's ordering is preserved as-is.
+     */
+    private void fetchMovies() {
+        // Derive a stable page number (1–100) from the room code.
+        // Math.abs guards against negative hashCode values.
+        int page = (roomCode != null && !roomCode.isEmpty())
+                ? (Math.abs(roomCode.hashCode()) % 100) + 1
+                : 1; // fallback for solo/test sessions
+
+        String bearer = "Bearer " + BuildConfig.TMDB_READ_ACCESS_TOKEN;
+
+        TmdbApiClient.getService()
+                .getTrendingMovies("day", "en-US", page, bearer)
+                .enqueue(new Callback<MovieListResponse>() {
+                    @Override
+                    public void onResponse(Call<MovieListResponse> call,
+                                           Response<MovieListResponse> response) {
+                        if (response.isSuccessful() && response.body() != null) {
+                            List<Movie> movies = response.body().getResults();
+                            if (movies != null && !movies.isEmpty()) {
+                                movieCardAdapter.setMovies(movies);
+                                Logger.d(TAG, "Loaded " + movies.size()
+                                        + " movies (page " + page + ")");
+                            }
+                        } else {
+                            Logger.w(TAG, "TMDB fetch failed: HTTP " + response.code());
+                            Toast.makeText(SwipingActivity.this,
+                                    "Could not load movies. Check your connection.",
+                                    Toast.LENGTH_SHORT).show();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<MovieListResponse> call, Throwable t) {
+                        Logger.e(TAG, "TMDB fetch error: " + t.getMessage());
+                        Toast.makeText(SwipingActivity.this,
+                                "Network error. Please check your connection.",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
     }
 }
+

--- a/app/src/main/res/drawable/gradient_card_overlay.xml
+++ b/app/src/main/res/drawable/gradient_card_overlay.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- gradient_card_overlay.xml
+     Full-width black scrim for the movie swipe card overlay.
+     Starts transparent at top, fades to near-opaque black at bottom.
+     Used for the collapsed (1/4) and expanded states of item_movie_card. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="270"
+        android:startColor="#00000000"
+        android:centerColor="#99000000"
+        android:endColor="#EE000000" />
+</shape>

--- a/app/src/main/res/layout/item_movie_card.xml
+++ b/app/src/main/res/layout/item_movie_card.xml
@@ -1,87 +1,138 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<!--
+    item_movie_card.xml  — Swiping activity movie card
+    ─────────────────────────────────────────────────
+    ROOT: FrameLayout  (transparent background, blends with black activity background)
+      ├── ImageView                    ← full-bleed backdrop / poster image
+      ├── TextView (rating badge)      ← ⭐ top-right corner, always visible
+      ├── View (gradient_card_overlay) ← black gradient scrim anchored to bottom
+      └── LinearLayout (info block)   ← anchored to bottom of card
+            ├── [ALWAYS VISIBLE]
+            │     ├── TextView  title (white, wrapped, 22sp bold)
+            │     └── LinearLayout  release date row (calendar_icon + color_text_secondary)
+            └── [COLLAPSED — hidden on tap, shown by default]
+                  ├── TextView  overview  (white, 13sp, wrapped)
+                  └── ChipGroup genres   (same style as item_movie_popular)
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp"
-    app:cardBackgroundColor="@color/color_surface"
-    app:cardCornerRadius="24dp"
-    app:cardElevation="8dp">
+    android:background="@android:color/transparent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <!-- Full-bleed backdrop / poster — Glide fills this -->
+    <ImageView
+        android:id="@+id/image_poster"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop"
+        android:contentDescription="@string/cd_movie_backdrop"
+        tools:src="@color/color_surface" />
 
-        <ImageView
-            android:id="@+id/image_poster"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:scaleType="centerCrop"
-            android:contentDescription="@string/label_movie_poster"
-            app:layout_constraintDimensionRatio="2:3"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:src="@android:drawable/ic_menu_gallery" />
+    <!-- ⭐ Rating badge — top-right corner, always visible -->
+    <TextView
+        android:id="@+id/text_movie_rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_margin="12dp"
+        android:paddingHorizontal="10dp"
+        android:paddingVertical="4dp"
+        android:textColor="@color/white"
+        android:textSize="13sp"
+        android:textStyle="bold"
+        tools:text="⭐ 8.4" />
 
-        <View
-            android:id="@+id/view_poster_overlay"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="@drawable/bg_poster_gradient"
-            app:layout_constraintBottom_toBottomOf="@id/image_poster"
-            app:layout_constraintEnd_toEndOf="@id/image_poster"
-            app:layout_constraintStart_toStartOf="@id/image_poster"
-            app:layout_constraintTop_toTopOf="@id/image_poster" />
+    <!-- Black gradient scrim — anchored to the bottom, grows upward.
+         In collapsed state the LinearLayout below is short (~25% of card).
+         In expanded state the LinearLayout grows pushing the scrim taller
+         via the gradient_card_overlay which fills it. -->
+    <View
+        android:id="@+id/view_card_scrim"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/gradient_card_overlay" />
 
+    <!-- Text info block — anchored bottom of the FrameLayout -->
+    <LinearLayout
+        android:id="@+id/layout_card_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="36dp"
+        android:paddingBottom="16dp">
+
+        <!-- ── Always-visible section ── -->
+
+        <!-- Title -->
         <TextView
             android:id="@+id/text_movie_title"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="8dp"
-            android:textColor="@color/color_text_primary"
-            android:textSize="24sp"
+            android:textColor="@android:color/white"
+            android:textSize="22sp"
             android:textStyle="bold"
-            android:maxLines="2"
+            android:maxLines="3"
             android:ellipsize="end"
-            app:layout_constraintBottom_toTopOf="@id/text_movie_overview"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/image_poster"
-            tools:text="Movie Title" />
+            tools:text="Dune: Part Two" />
 
-        <TextView
-            android:id="@+id/text_movie_rating"
+        <!-- Release date row (calendar icon + date text) -->
+        <LinearLayout
+            android:id="@+id/row_card_release_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="20dp"
-            android:textColor="@color/color_secondary"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/image_poster"
-            tools:text="⭐ 8.5" />
+            android:layout_marginTop="6dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
+            <ImageView
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:src="@drawable/calendar_icon"
+                android:contentDescription="@null"
+                app:tint="@color/color_text_secondary" />
+
+            <TextView
+                android:id="@+id/text_movie_release_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:textColor="@color/color_text_secondary"
+                android:textSize="12sp"
+                tools:text="2024-03-01" />
+        </LinearLayout>
+
+        <!-- ── Expanded-only section (GONE by default, shown on tap) ── -->
+
+        <!-- Overview / description -->
         <TextView
             android:id="@+id/text_movie_overview"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="20dp"
-            android:textColor="@color/color_text_secondary"
-            android:textSize="14sp"
-            android:maxLines="5"
-            android:ellipsize="end"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/text_movie_title"
-            tools:text="Movie overview text goes here. This is a longer description of the movie plot and storyline." />
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:textColor="#CCFFFFFF"
+            android:textSize="13sp"
+            android:lineSpacingMultiplier="1.3"
+            android:visibility="gone"
+            tools:text="Follow the mythic journey of Paul Atreides as he unites with Chani and the Fremen while on a warpath of revenge against the conspirators who destroyed his family."
+            tools:visibility="visible" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.material.card.MaterialCardView>
+        <!-- Genre chips -->
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chip_group_card_genres"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            app:singleLine="false"
+            app:chipSpacingVertical="-9dp"
+            app:chipSpacingHorizontal="5dp"
+            tools:visibility="visible" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,9 @@
 
     <!-- Swiping -->
     <string name="label_movie_poster">Movie poster</string>
+    <string name="cd_movie_backdrop">Movie backdrop</string>
     <string name="label_swiping_status">Swiping:</string>
+
     <string name="btn_yes">Yes</string>
     <string name="btn_no">No</string>
     <string name="btn_exit_session">Exit Session</string>

--- a/notes/APP_DEV_PLAN.md
+++ b/notes/APP_DEV_PLAN.md
@@ -596,22 +596,24 @@ Splash → **Login** (if not authenticated) | **Home** (Main) (if authenticated)
 
 **Estimated Time:** 5-6 days
 
-### **Step 7.1: Movie Card Stack**
+### **Step 7.1: Movie Card Stack** ✅ Done
 
 **Tasks:**
 
-- [ ] Set up ViewPager2 or custom card stack
-- [ ] Create MovieCardAdapter
-- [ ] Display movie data in cards
-- [ ] Load movie images
-- [ ] Implement card animations
+- [x] Set up ViewPager2 with `MovieCardAdapter`
+- [x] Create `MovieCardAdapter` (ViewPager2 `RecyclerView.Adapter`)
+- [x] Display movie data in cards (title, rating, overview)
+- [x] Load movie backdrop/poster images via Glide
+- [x] Implement card animations (`CompositePageTransformer` — scale + alpha + margin gap)
 
-**Files to Create:**
+**Files Created/Modified:**
 
-- `app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/MovieCardAdapter.java`
-- `app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java`
+- `ui/swiping/MovieCardAdapter.java` _(new — ViewPager2 adapter)_
+- `ui/swiping/SwipingActivity.java` _(updated — fetches trending movies, wires adapter)_
 
-**Deliverable:** Movie card stack display
+> Yes/No vote logic is stubbed (`advanceCard()`) — will be wired in Step 7.2.
+
+**Deliverable:** ✅ Movie card stack display
 
 ---
 


### PR DESCRIPTION
…I polish

SwipingActivity
- Replace hardcoded page=1 with deterministic room-code-seeded page number (Math.abs(roomCode.hashCode()) % 100 + 1), so all devices in the same lobby always fetch the same TMDB page without Firebase coordination. Falls back to page 1 for solo/test sessions (no room code).
- Disable ViewPager2 user input (setUserInputEnabled(false)) — cards now only advance via Yes/No button taps, ensuring every transition is a deliberate recorded vote. Free swiping no longer skips unvoted movies. TmdbApiService
- Added @Query("page") int page parameter to getTrendingMovies() so callers can specify which result page to fetch. HomeActivity still passes page=1 (no behaviour change on Home screen). Movie.java
- Added setters for all fields to support Firebase deserialization (retained for Phase 7.2 vote recording). FirebaseRepository.java
- Added saveMovieQueue(), listenMovieQueue(), and MovieQueueCallback interface (retained for Phase 7.2 vote recording, not currently called). MovieCardAdapter / item_movie_card.xml
- formatReleaseDate() now parses YYYY-MM-DD → "MMM yyyy" (e.g. Feb 2026)
- Added star rating badge (top-right, white text, semi-transparent bg)
- Default card state changed to expanded (overview + genres visible); tap to collapse, tap again to expand Reverted: Firebase shared movie queue approach abandoned due to Firebase write-propagation race condition. Deterministic page hashing solves the identical-movie-deck problem without async coordination.