### PR TITLE
feat(swiping): implement swipe gesture detection with animated feedback

### DIFF
--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java
@@ -71,9 +71,16 @@ public class SwipingActivity extends BaseActivity {
         movieCardAdapter = new MovieCardAdapter();
         viewPagerMovies.setAdapter(movieCardAdapter);
 
-        // Disable free swiping — cards only advance via the Yes / No buttons.
-        // This ensures every card transition is a deliberate vote, not an accidental swipe.
-        // (Phase 7.2 will add swipe-left = No / swipe-right = Yes touch shortcuts on the card itself.)
+        // Route swipe gestures through the same Yes/No handlers as the buttons.
+        // This ensures both input methods (swipe gesture + button tap) are unified
+        // and will both trigger vote recording in Phase 7.2.
+        movieCardAdapter.setSwipeCallback(new MovieCardAdapter.SwipeCallback() {
+            @Override public void onSwipedYes() { handleYes(); }
+            @Override public void onSwipedNo()  { handleNo();  }
+        });
+
+        // Disable ViewPager2's own swipe — cards only advance via gesture on the card
+        // itself (routed through SwipeCallback above) or via the Yes/No buttons.
         viewPagerMovies.setUserInputEnabled(false);
 
         viewPagerMovies.setOffscreenPageLimit(2);

--- a/app/src/main/res/drawable/bg_swipe_label_no.xml
+++ b/app/src/main/res/drawable/bg_swipe_label_no.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Rounded border for NO swipe label (red) -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke android:width="3dp" android:color="#F44336" />
+    <corners android:radius="6dp" />
+    <solid android:color="#22F44336" />
+</shape>

--- a/app/src/main/res/drawable/bg_swipe_label_yes.xml
+++ b/app/src/main/res/drawable/bg_swipe_label_yes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Rounded border for YES swipe label (green) -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke android:width="3dp" android:color="#4CAF50" />
+    <corners android:radius="6dp" />
+    <solid android:color="#224CAF50" />
+</shape>

--- a/app/src/main/res/layout/item_movie_card.xml
+++ b/app/src/main/res/layout/item_movie_card.xml
@@ -135,4 +135,38 @@
 
     </LinearLayout>
 
+    <!-- ✅ YES overlay — shown when swiping right (green tint) -->
+    <TextView
+        android:id="@+id/overlay_swipe_yes"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start|top"
+        android:layout_margin="28dp"
+        android:text="YES ✓"
+        android:textColor="#4CAF50"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:paddingHorizontal="14dp"
+        android:paddingVertical="8dp"
+        android:background="@drawable/bg_swipe_label_yes"
+        android:rotation="-20"
+        android:visibility="invisible" />
+
+    <!-- ❌ NO overlay — shown when swiping left (red tint) -->
+    <TextView
+        android:id="@+id/overlay_swipe_no"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|top"
+        android:layout_margin="28dp"
+        android:text="NO ✗"
+        android:textColor="#F44336"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:paddingHorizontal="14dp"
+        android:paddingVertical="8dp"
+        android:background="@drawable/bg_swipe_label_no"
+        android:rotation="20"
+        android:visibility="invisible" />
+
 </FrameLayout>

--- a/notes/APP_DEV_PLAN.md
+++ b/notes/APP_DEV_PLAN.md
@@ -617,21 +617,27 @@ Splash → **Login** (if not authenticated) | **Home** (Main) (if authenticated)
 
 ---
 
-### **Step 7.2: Swipe Gesture Detection**
+### **Step 7.2: Swipe Gesture Detection** ✅ Done
 
 **Tasks:**
 
-- [ ] Implement swipe left (No) detection
-- [ ] Implement swipe right (Yes) detection
-- [ ] Add visual feedback during swipe
-- [ ] Animate card removal
-- [ ] Load next card after swipe
+- [x] Implement swipe left (No) detection
+- [x] Implement swipe right (Yes) detection
+- [x] Add visual feedback during swipe
+- [x] Animate card removal
+- [x] Load next card after swipe
 
-**Files to Modify:**
+**Files Created/Modified:**
 
-- `app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java`
+- `res/drawable/bg_swipe_label_yes.xml` _(new — green bordered background for YES label)_
+- `res/drawable/bg_swipe_label_no.xml` _(new — red bordered background for NO label)_
+- `res/layout/item_movie_card.xml` _(updated — added YES/NO overlay TextViews)_
+- `ui/swiping/MovieCardAdapter.java` _(rewritten — OnTouchListener, drag/rotate, flyOff, snapBack, SwipeCallback)_
+- `ui/swiping/SwipingActivity.java` _(updated — registered SwipeCallback routing to handleYes/handleNo)_
 
-**Deliverable:** Working swipe gestures
+> Swipe and Yes/No button both call the same `handleYes()`/`handleNo()` — unified for Step 7.3 vote recording.
+
+**Deliverable:** ✅ Working swipe gestures
 
 ---
 

--- a/notes/LOGS_CHANGES.md
+++ b/notes/LOGS_CHANGES.md
@@ -1,5 +1,35 @@
 # CineMatch – Log of Changes
 
+## 2026-02-24 – Feature: Phase 7.2 – Swipe Gesture Detection (SwipingActivity)
+
+**What:** Movie cards now support swipe-left (No) and swipe-right (Yes) gestures directly on the card view, with animated visual feedback and fly-off / snap-back transitions.
+
+**Gesture flow:**
+
+- **Drag right** → card translates + rotates clockwise → **YES ✓** label fades in (green)
+- **Drag left** → card translates + rotates counter-clockwise → **NO ✗** label fades in (red)
+- **Release ≥ 120dp** → `flyOff()` animation (card flies off-screen) → fires `SwipeCallback` → `advanceCard()`
+- **Release < 120dp** → `snapBack()` animation (card springs back to rest)
+- **Short tap (no drag)** → toggles expanded/collapsed info panel (unchanged)
+
+**Architecture:**
+
+- `MovieCardAdapter.SwipeCallback` interface (`onSwipedYes()` / `onSwipedNo()`) decouples gesture detection from vote logic — both swipe gesture AND Yes/No button tap call the exact same `handleYes()` / `handleNo()` in `SwipingActivity`. Ready for Step 7.3 vote recording with zero changes to gesture code.
+- `ViewPager2.setUserInputEnabled(false)` is retained — ViewPager2's own swipe is still off. Gestures are handled by `OnTouchListener` on the card view itself.
+
+**Files created:**
+
+- **`res/drawable/bg_swipe_label_yes.xml`** _(new)_ — Rounded green-bordered semi-transparent background for YES label
+- **`res/drawable/bg_swipe_label_no.xml`** _(new)_ — Rounded red-bordered semi-transparent background for NO label
+
+**Files modified:**
+
+- **`res/layout/item_movie_card.xml`** — Added `overlay_swipe_yes` (`start|top`, −20° tilt, green) and `overlay_swipe_no` (`end|top`, +20° tilt, red); both `INVISIBLE` by default
+- **`ui/swiping/MovieCardAdapter.java`** — Full rewrite: added `SwipeCallback` interface, `attachTouchListener()` per card (translate, rotate, overlay alpha), `flyOff(boolean isYes)`, `snapBack()`, `resetCard()` helpers; constants: `SWIPE_THRESHOLD_DP=120`, `MAX_ROTATION_DEG=20`, `FLY_DURATION_MS=280`, `SNAP_DURATION_MS=250`
+- **`ui/swiping/SwipingActivity.java`** — Registered `SwipeCallback` in `setupViewPager()` routing `onSwipedYes()→handleYes()` and `onSwipedNo()→handleNo()`
+
+---
+
 ## 2026-02-24 – SwipingActivity: Lock Swipe to Yes/No Buttons Only
 
 **What:** Users could freely swipe between movie cards on the ViewPager2 without voting. This broke the voting mechanic — skipped cards would have no recorded vote.


### PR DESCRIPTION
MovieCardAdapter (full rewrite)

- Added SwipeCallback interface (onSwipedYes / onSwipedNo) to decouple

gesture detection from vote logic

- Attached OnTouchListener per card:

drag right → translate + rotate clockwise + fade YES label (green)

drag left → translate + rotate counter-clockwise + fade NO label (red)

- flyOff(boolean isYes): card flies off-screen on commit, fires SwipeCallback

- snapBack(): card springs back if released before 120dp threshold

- resetCard(): clears all transforms/overlays on bind and after fly-off

- Short tap (no drag) still toggles expanded/collapsed info panel

- Constants: SWIPE_THRESHOLD_DP=120, MAX_ROTATION_DEG=20,

FLY_DURATION_MS=280, SNAP_DURATION_MS=250

SwipingActivity

- Registered SwipeCallback in setupViewPager():

onSwipedYes() → handleYes(), onSwipedNo() → handleNo()

- ViewPager2.setUserInputEnabled(false) retained — swipe handled on card view itself, not ViewPager2; both gesture and button use same handlers item_movie_card.xml
- Added overlay_swipe_yes (start|top, -20° tilt, green, INVISIBLE)
- Added overlay_swipe_no (end|top, +20° tilt, red, INVISIBLE)

New drawables
- bg_swipe_label_yes.xml: rounded green-bordered semi-transparent bg
- bg_swipe_label_no.xml: rounded red-bordered semi-transparent bg