### PR TITLE
feat(swiping): implement end-of-deck pagination and unify host-member…

### DIFF
--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/CreateLobbyActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/CreateLobbyActivity.java
@@ -223,6 +223,9 @@ public class CreateLobbyActivity extends BaseActivity {
 
     private void startSwipingSession() {
         btnStartSwiping.setEnabled(false);
+        // Clear any stale currentPage from a previous session BEFORE any device
+        // enters SwipingActivity. The host will write the real initialPage there.
+        firebaseRepo.setCurrentPage(roomCode, 0);
         firebaseRepo.setLobbyStatus(roomCode, Constants.LOBBY_STATUS_SWIPING);
         // Status listener above fires for all devices
     }
@@ -258,7 +261,7 @@ public class CreateLobbyActivity extends BaseActivity {
         if (roomCode != null) {
             firebaseRepo.removeMember(roomCode, currentUserId, null);
         }
-        firebaseRepo.detachListeners();
+        firebaseRepo.detachLobbyListeners();
         startActivity(new Intent(this, HomeActivity.class)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
         finish();
@@ -266,7 +269,7 @@ public class CreateLobbyActivity extends BaseActivity {
 
     @Override
     protected void onDestroy() {
-        firebaseRepo.detachListeners();
+        firebaseRepo.detachLobbyListeners();
         super.onDestroy();
     }
 }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/LobbyActivity.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/ui/lobby/LobbyActivity.java
@@ -216,6 +216,10 @@ public class LobbyActivity extends BaseActivity {
         // (including this host) and each device navigates to SwipingActivity independently.
         // Each device fetches TMDB page 1 directly — deterministic, so all users
         // see identical movies without any Firebase coordination needed.
+        // Clear any stale currentPage from a previous session BEFORE any device
+        // enters SwipingActivity. This guarantees the listener fires with 0 first
+        // (which is skipped), then the host writes the real initialPage.
+        firebaseRepo.setCurrentPage(roomCode, 0);
         firebaseRepo.setLobbyStatus(roomCode, Constants.LOBBY_STATUS_SWIPING);
         sessionStarted = true;
         navigateToSwiping();
@@ -264,7 +268,7 @@ public class LobbyActivity extends BaseActivity {
 
     @Override
     protected void onDestroy() {
-        firebaseRepo.detachListeners();
+        firebaseRepo.detachLobbyListeners();
         super.onDestroy();
     }
 }

--- a/app/src/main/java/com/example/finalprojectandroiddev2/utils/Constants.java
+++ b/app/src/main/java/com/example/finalprojectandroiddev2/utils/Constants.java
@@ -21,6 +21,7 @@ public final class Constants {
     public static final String NODE_MOVIES = "movies";
     public static final String NODE_VOTES = "votes";
     public static final String NODE_MATCHED_MOVIE = "matchedMovie";
+    public static final String NODE_CURRENT_PAGE = "currentPage";
 
     // Lobby status values
     public static final String LOBBY_STATUS_WAITING = "waiting";

--- a/app/src/main/res/drawable/reload_icon.xml
+++ b/app/src/main/res/drawable/reload_icon.xml
@@ -1,0 +1,42 @@
+<!--
+MIT License
+
+Copyright (c) 2020-2025 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="@color/black"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M19.933,13.041a8,8 0 1,1 -9.925,-8.788c3.899,-1 7.935,1.007 9.425,4.747" />
+    <path
+        android:strokeColor="@color/black"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:pathData="M20,4v5h-5" />
+</vector>

--- a/app/src/main/res/layout/item_end_of_deck.xml
+++ b/app/src/main/res/layout/item_end_of_deck.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:cardBackgroundColor="@color/color_surface"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="32dp">
+
+        <!-- Popcorn emoji / icon area -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🍿"
+            android:textSize="64sp"
+            android:layout_marginBottom="24dp" />
+
+        <!-- Title -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_end_of_deck_title"
+            android:textColor="@color/color_text_primary"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:layout_marginBottom="12dp" />
+
+        <!-- Subtitle -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_end_of_deck_subtitle"
+            android:textColor="@color/color_text_secondary"
+            android:textSize="14sp"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.4"
+            android:layout_marginBottom="40dp" />
+
+        <!-- Host only: Load More button -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_load_more"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_load_more"
+            android:textColor="@color/color_primary"
+            android:textSize="15sp"
+            android:visibility="gone"
+            app:icon="@drawable/reload_icon"
+            app:iconGravity="textStart"
+            app:iconPadding="8dp"
+            app:iconTint="@color/color_primary" />
+
+        <!-- Member only: waiting hint -->
+        <TextView
+            android:id="@+id/text_waiting_host"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_waiting_host_load_more"
+            android:textColor="@color/color_text_secondary"
+            android:textSize="13sp"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.4"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,10 @@
     <string name="btn_yes">Yes</string>
     <string name="btn_no">No</string>
     <string name="btn_exit_session">Exit Session</string>
+    <string name="btn_load_more">Load More Movies</string>
+    <string name="label_end_of_deck_title">That\'s all for now! 🍿</string>
+    <string name="label_end_of_deck_subtitle">You\'ve seen all the movies in this deck.\nNo match yet? Try loading more!</string>
+    <string name="label_waiting_host_load_more">Waiting for the host to load more movies…\nHang tight!</string>
 
     <!-- Match -->
     <string name="msg_match_found">🎉 Match Found! 🎉</string>

--- a/notes/APP_DEV_PLAN.md
+++ b/notes/APP_DEV_PLAN.md
@@ -690,21 +690,27 @@ No votes are intentionally not written — absence of a user entry means No.
 
 ---
 
-### **Step 7.5: Movie Queue Management**
+### **Step 7.5: Movie Queue Management** ✅ Done
 
 **Tasks:**
 
-- [ ] Fetch initial movie list (20-30 movies)
-- [ ] Load more movies when queue is low
-- [ ] Prevent duplicate movies
-- [ ] Handle API pagination
+- [x] Fetch initial movie list (20-30 movies)
+- [x] Load more movies when queue is low — host-triggered "Load More"
+- [x] Prevent duplicate movies — `appendMovies()` deduplicates by movie ID
+- [x] Handle API pagination — `currentPage` incremented per Load More
 
-**Files to Modify:**
+**Design:** Host-controlled Load More. When the deck runs out, the host sees a **Load More Movies** button; members see **"Waiting for host to load more movies…"** until the host acts. Firebase `currentPage` broadcasts the next page number to all members so every device appends the identical new movies.
 
-- `app/src/main/java/com/example/finalprojectandroiddev2/ui/swiping/SwipingActivity.java`
-- `app/src/main/java/com/example/finalprojectandroiddev2/data/repository/MovieRepository.java`
+**Files Created/Modified:**
 
-**Deliverable:** Continuous movie queue
+- `utils/Constants.java` _(updated — `NODE_CURRENT_PAGE`)_
+- `ui/swiping/MovieCardAdapter.java` _(updated — `appendMovies()` with ID-based dedup)_
+- `res/layout/activity_swiping.xml` _(updated — end-of-deck overlay with `btn_load_more` + `text_waiting_host`)_
+- `res/values/strings.xml` _(updated — `btn_load_more`, `label_end_of_deck_title/subtitle`, `label_waiting_host_load_more`)_
+- `data/repository/FirebaseRepository.java` _(updated — `PageCallback`, `setCurrentPage()`, `listenCurrentPage()`, `detachPageListener()`)_
+- `ui/swiping/SwipingActivity.java` _(updated — `isHost` detection, `showEndOfDeck()`, `loadMoreMovies()`, `listenForPageChanges()`)_
+
+**Deliverable:** ✅ Continuous movie queue
 
 ---
 


### PR DESCRIPTION
… page synchronization

* Engineered appendMovies() in MovieCardAdapter with strict ID deduplication logic
* Deployed dynamic end-of-deck UI overlays for host (Load More) and member (waiting hint)
* Refactored SwipingActivity page sync: host fetches locally and broadcasts NODE_CURRENT_PAGE to Firebase
* Transitioned members to reactive fetchMoviesForPage() via listenCurrentPage() triggers
* Optimized isHost resolution using Intent EXTRA_IS_HOST to bypass async database latency
* Reset currentPage to 0 in pre-session activities to clear stale state payloads
* Updated FirebaseRepository lifecycle: detachLobbyListeners() now isolates lobby teardown, [Unverified claim] which fixes the premature termination of SwipingActivity listeners
* Replaced legacy fetchMovies() with fetchMoviesForPage() using initialLoadDone flag for strict state management